### PR TITLE
fix: [#945] ignore empty cache prefix

### DIFF
--- a/cache.go
+++ b/cache.go
@@ -38,7 +38,7 @@ func NewCache(ctx context.Context, config config.Config, process process.Process
 
 	return &Cache{
 		ctx:      ctx,
-		prefix:   fmt.Sprintf("%s:", config.GetString("cache.prefix")),
+		prefix:   config.GetString("cache.prefix"),
 		instance: client,
 		store:    store,
 		config:   config,
@@ -270,5 +270,9 @@ func (r *Cache) WithContext(ctx context.Context) contractscache.Driver {
 }
 
 func (r *Cache) key(key string) string {
-	return r.prefix + key
+	if r.prefix == "" {
+		return key
+	}
+
+	return r.prefix + ":" + key
 }

--- a/cache_test.go
+++ b/cache_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/goravel/framework/process"
 	"github.com/goravel/framework/support/env"
 	"github.com/spf13/cast"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/suite"
 )
 
@@ -434,6 +435,25 @@ func (s *CacheTestSuite) TestRememberForever() {
 	s.Nil(err)
 	s.Equal("World1", value)
 	s.True(s.cache.Flush())
+}
+
+func TestCacheKey(t *testing.T) {
+	tests := []struct {
+		name   string
+		prefix string
+		key    string
+		want   string
+	}{
+		{name: "with prefix", prefix: "goravel_cache", key: "name", want: "goravel_cache:name"},
+		{name: "empty prefix is ignored", prefix: "", key: "name", want: "name"},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			cache := &Cache{prefix: test.prefix}
+			assert.Equal(t, test.want, cache.key(test.key))
+		})
+	}
 }
 
 func mockGetClient(mockConfig *mocksconfig.Config, docker *Docker) {


### PR DESCRIPTION
By default the Redis cache joins the configured `cache.prefix` to every key with a `:` separator. The separator was added unconditionally, so when `cache.prefix` is empty the keys still received a leading `:` (for example `:name`). That makes keys longer than necessary and, more importantly, inconsistent with the keys you get when talking to Redis directly with a raw client, where the same value would be stored under `name`.

## What is changing

- `NewCache` stores the configured prefix as-is instead of pre-joining the `:` separator.
- `key` adds the `<prefix>:` separator only when a prefix is configured. An empty prefix is ignored, so the stored key is exactly the key you pass in.

## Example

With `cache.prefix` empty:

```
Before: facades.Cache().Put("name", ...) -> Redis key ":name"
After:  facades.Cache().Put("name", ...) -> Redis key "name"
```

With `cache.prefix = "goravel_cache"` the behavior is unchanged: the key is `goravel_cache:name`.

The in-memory driver carries the same fix in goravel/framework#1496 so both drivers behave consistently.

Ref: goravel/goravel#945
